### PR TITLE
Add loongarch basic support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # on a multicore machine.
 list(APPEND MOLD_ELF_TARGETS
   X86_64 I386 ARM64 ARM32 RV32LE RV32BE RV64LE RV64BE
-  PPC64V1 PPC64V2 S390X SPARC64 M68K)
+  PPC64V1 PPC64V2 S390X SPARC64 M68K LOONGARCH32 LOONGARCH64)
 
 list(APPEND MOLD_ELF_TEMPLATE_FILES
   elf/cmdline.cc
@@ -330,6 +330,7 @@ target_sources(mold PRIVATE
   elf/arch-arm32.cc
   elf/arch-arm64.cc
   elf/arch-i386.cc
+  elf/arch-loongarch.cc
   elf/arch-m68k.cc
   elf/arch-ppc64v1.cc
   elf/arch-ppc64v2.cc

--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -1,0 +1,699 @@
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
+
+#include "mold.h"
+
+namespace mold::elf {
+
+static u32 hi20(u32 val) { return (val + 0x800) >> 12; }
+static u32 lo12(u32 val) { return val & 0xfff; }
+
+static i64 alau32_hi20(i64 val, i64 pc) {
+  return ((val + ((val & 0x800) << 1)) & ~0xfffl) - (pc & ~0xfffl);
+}
+
+static i64 alau64_hi32(i64 val, i64 pc) {
+  return (val - ((val & 0x800l) << 21)) - (pc & ~0xffffffffl);
+}
+
+static void writeJ20(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111110'00000000'00000000'00011111;
+  *(ul32 *)loc |= (val & 0xfffff) << 5;
+}
+
+static void writeK12(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111111'11110000'00000011'11111111;
+  *(ul32 *)loc |= (val & 0xfff) << 10;
+}
+
+static void writeD5k16(u8 *loc, u32 val) {
+  u32 hi = val >> 16;
+  *(ul32 *)loc &= 0b11111100'00000000'00000011'11100000;
+  *(ul32 *)loc |= ((val & 0xffff) << 10) | (hi & 0x1f);
+}
+
+static void writeD10k16(u8 *loc, u32 val) {
+  u32 hi = val >> 16;
+  *(ul32 *)loc &= 0b11111100'00000000'00000000'00000000;
+  *(ul32 *)loc |= ((val & 0xffff) << 10) | (hi & 0x3ff);
+}
+
+static void writeK16(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111100'00000000'00000011'11111111;
+  *(ul32 *)loc |= (val & 0xffff) << 10;
+}
+
+template <typename E>
+void write_plt_header(Context<E> &ctx, u8 *buf) {
+  static const ul32 insn_64[] = {
+    0x1c00'000e, // pcaddu12i $t2, %hi(%pcrel(.got.plt))
+    0x0011'bdad, // sub.d     $t1, $t1, $t3
+    0x28c0'01cf, // ld.d      $t3, $t2, %lo(%pcrel(.got.plt)) # _dl_runtime_resolve
+    0x02ff'51ad, // addi.d    $t1, $t1, -44                   # .plt entry
+    0x02c0'01cc, // addi.d    $t0, $t2, %lo(%pcrel(.got.plt)) # &.got.plt
+    0x0045'05ad, // srli.d    $t1, $t1, 1                     # .plt entry offset
+    0x28c0'218c, // ld.d      $t0, $t0, 8                     # link map
+    0x4c00'01e0, // jr        $t3
+  };
+
+  static const ul32 insn_32[] = {
+    0x1c00'000e, // pcaddu12i $t2, %hi(%pcrel(.got.plt))
+    0x0011'3dad, // sub.w     $t1, $t1, $t3
+    0x2880'01cf, // ld.w      $t3, $t2, %lo(%pcrel(.got.plt)) # _dl_runtime_resolve
+    0x02bf'51ad, // addi.w    $t1, $t1, -44                   # .plt entry
+    0x0280'01cc, // addi.w    $t0, $t2, %lo(%pcrel(.got.plt)) # &.got.plt
+    0x0044'89ad, // srli.w    $t1, $t1, 2                     # .plt entry offset
+    0x2880'118c, // ld.w      $t0, $t0, 4                     # link map
+    0x4c00'01e0, // jr        $t3
+  };
+
+  u64 gotplt = ctx.gotplt->shdr.sh_addr;
+  u64 plt = ctx.plt->shdr.sh_addr;
+  u32 offset = gotplt - plt;
+
+  if constexpr (E::is_64)
+    if (gotplt - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make plt header";
+
+  if constexpr (E::is_64)
+    memcpy(buf, insn_64, sizeof(insn_64));
+  else
+    memcpy(buf, insn_32, sizeof(insn_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 8, lo12(offset));
+  writeK12(buf + 16, lo12(offset));
+}
+
+static const ul32 plt_entry_64[] = {
+  0x1c00000f, // pcaddu12i $t3, %hi(%pcrel(func@.got.plt))
+  0x28c001ef, // ld.d      $t3, $t3, %lo(%pcrel(func@.got.plt))
+  0x4c0001ed, // jirl      $t1, $t3, 0
+  0x03400000, // nop
+};
+
+static const ul32 plt_entry_32[] = {
+  0x1c00000f, // pcaddu12i $t3, %hi(%pcrel(func@.got.plt))
+  0x288001ef, // ld.w      $t3, $t3, %lo(%pcrel(func@.got.plt))
+  0x4c0001ed, // jirl      $t1, $t3, 0
+  0x03400000, // nop
+};
+
+template <typename E>
+void write_plt_entry(Context<E> &ctx, u8 *buf, Symbol<E> &sym) {
+  u64 gotplt = sym.get_gotplt_addr(ctx);
+  u64 plt = sym.get_plt_addr(ctx);
+  u32 offset = gotplt - plt;
+
+  if constexpr (E::is_64)
+    if (gotplt - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make plt entry";
+
+  if constexpr (E::is_64)
+    memcpy(buf, plt_entry_64, sizeof(plt_entry_64));
+  else
+    memcpy(buf, plt_entry_32, sizeof(plt_entry_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 4, lo12(offset));
+}
+
+template <typename E>
+void write_pltgot_entry(Context<E> &ctx, u8 *buf, Symbol<E> &sym) {
+  u64 got = sym.get_got_addr(ctx);
+  u64 plt = sym.get_plt_addr(ctx);
+  u32 offset = got - plt;
+
+  if constexpr (E::is_64)
+    if (got - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make pltgot entry";
+
+  if constexpr (E::is_64)
+    memcpy(buf, plt_entry_64, sizeof(plt_entry_64));
+  else
+    memcpy(buf, plt_entry_32, sizeof(plt_entry_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 4, lo12(offset));
+}
+
+template <typename E>
+void EhFrameSection<E>::apply_reloc(Context<E> &ctx, const ElfRel<E> &rel,
+                                    u64 offset, u64 val) {
+  u8 *loc = ctx.buf + this->shdr.sh_offset + offset;
+
+  switch (rel.r_type) {
+  case R_NONE:
+    break;
+  case R_LARCH_ADD8:
+    *loc += val;
+    break;
+  case R_LARCH_ADD16:
+    *(U16<E> *)loc += val;
+    break;
+  case R_LARCH_ADD32:
+    *(U32<E> *)loc += val;
+    break;
+  case R_LARCH_ADD64:
+    *(U64<E> *)loc += val;
+    break;
+  case R_LARCH_SUB8:
+    *loc -= val;
+    break;
+  case R_LARCH_SUB16:
+    *(U16<E> *)loc -= val;
+    break;
+  case R_LARCH_SUB32:
+    *(U32<E> *)loc -= val;
+    break;
+  case R_LARCH_SUB64:
+    *(U64<E> *)loc -= val;
+    break;
+  case R_LARCH_32_PCREL:
+    *(U32<E> *)loc = val - this->shdr.sh_addr - offset;
+    break;
+  default:
+    Fatal(ctx) << "unsupported relocation in .eh_frame: " << rel;
+  }
+}
+
+template <typename E>
+void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  ElfRel<E> *dynrel = nullptr;
+  if (ctx.reldyn)
+    dynrel = (ElfRel<E> *)(ctx.buf + ctx.reldyn->shdr.sh_offset +
+                           file.reldyn_offset + this->reldyn_offset);
+
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    // Maybe do something in the future.
+    if (rel.r_type == R_LARCH_RELAX)
+      continue;
+
+    // Relocation notes, ignore them.
+    if (rel.r_type == R_LARCH_MARK_LA || rel.r_type == R_LARCH_MARK_PCREL)
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+    u8 *loc = base + rel.r_offset;
+
+    auto checkrange = [&](i64 val, i64 lo, i64 hi) {
+      if (val < lo || hi <= val)
+        Error(ctx) << *this << ": relocation " << rel << " against "
+                   << sym << " out of range: " << val << " is not in ["
+                   << lo << ", " << hi << ")";
+    };
+
+    auto checkalign = [&](i64 val, i64 align) {
+      if (val & (align - 1))
+        Error(ctx) << *this << ": relocation " << rel << " against "
+                   << sym << " unaligned: " << val << " needs "
+                   << align << " bytes aligned";
+    };
+
+#define S   (sym.get_addr(ctx))
+#define A   (rel.r_addend)
+#define P   (get_addr() + rel.r_offset)
+#define G   (sym.get_got_idx(ctx) * sizeof(Word<E>))
+#define GP  (ctx.got->shdr.sh_addr)
+#define TP  (ctx.tp_addr)
+#define GD  (sym.get_tlsgd_addr(ctx))
+#define IE  (sym.get_gottp_addr(ctx))
+
+    auto get_got_or_gd = [&]() {
+      if (sym.has_tlsgd(ctx))
+        return GD;
+      else
+        return GP + G;
+    };
+
+    switch (rel.r_type) {
+    case R_LARCH_32: {
+      if constexpr (E::is_64)
+        *(U32<E> *)loc = S + A;
+      else
+        apply_dyn_absrel(ctx, sym, rel, loc, S, A, P, dynrel);
+      break;
+    }
+    case R_LARCH_64: {
+      assert(E::is_64);
+      apply_dyn_absrel(ctx, sym, rel, loc, S, A, P, dynrel);
+      break;
+    }
+    case R_LARCH_B16: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 17), 1ll << 17);
+      checkalign(val, 4);
+      writeK16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_B21: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 22), 1ll << 22);
+      checkalign(val, 4);
+      writeD5k16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_B26: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 27), 1ll << 27);
+      checkalign(val, 4);
+      writeD10k16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_ABS_HI20: {
+      i64 val = S + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_ABS_LO12: {
+      i64 val = S + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_ABS64_LO20: {
+      i64 val = S + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_ABS64_HI12: {
+      i64 val = S + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_PCALA_HI20: {
+      i64 val = alau32_hi20(S + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_PCALA_LO12: {
+      i64 val = S + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_PCALA64_LO20: {
+      i64 val = alau64_hi32(S + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_PCALA64_HI12: {
+      i64 val = alau64_hi32(S + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_GOT_PC_HI20: {
+      i64 val = alau32_hi20(GP + G + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_GOT_PC_LO12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_GOT64_PC_LO20: {
+      i64 val = alau64_hi32(get_got_or_gd() + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_GOT64_PC_HI12: {
+      i64 val = alau64_hi32(get_got_or_gd() + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_GOT_HI20: {
+      i64 val = GP + G + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_GOT_LO12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_GOT64_LO20: {
+      i64 val = get_got_or_gd() + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_GOT64_HI12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_LE_HI20: {
+      i64 val = S + A - TP;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_LE_LO12: {
+      i64 val = S + A - TP;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_LE64_LO20: {
+      i64 val = S + A - TP;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_LE64_HI12: {
+      i64 val = S + A - TP;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_IE_PC_HI20: {
+      i64 val = alau32_hi20(IE + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_IE_PC_LO12: {
+      i64 val = IE + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_IE64_PC_LO20: {
+      i64 val = alau64_hi32(IE + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_IE64_PC_HI12: {
+      i64 val = alau64_hi32(IE + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_IE_HI20: {
+      i64 val = IE + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_IE_LO12: {
+      i64 val = IE + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_IE64_LO20: {
+      i64 val = IE + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_IE64_HI12: {
+      i64 val = IE + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_LD_PC_HI20:
+    case R_LARCH_TLS_GD_PC_HI20: {
+      i64 val = alau32_hi20(GD + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_LD_HI20:
+    case R_LARCH_TLS_GD_HI20: {
+      i64 val = GD + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_ADD8:
+      *loc += S + A;
+      break;
+    case R_LARCH_ADD16:
+      *(U16<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD32:
+      *(U32<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD64:
+      *(U64<E> *)loc += S + A;
+      break;
+    case R_LARCH_SUB8:
+      *loc -= S + A;
+      break;
+    case R_LARCH_SUB16:
+      *(U16<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB32:
+      *(U32<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB64:
+      *(U64<E> *)loc -= S + A;
+      break;
+    case R_LARCH_32_PCREL:
+      *(U32<E> *)loc = S + A - P;
+      break;
+    // A stack machine (read: global mutable state) is necessary for properly
+    // computing these relocs, and these relocs are already deprecated after
+    // the release of LoongArch ELF psABI v2.00, so we are not going to
+    // implement them.
+    case R_LARCH_SOP_PUSH_PCREL:
+    case R_LARCH_SOP_PUSH_ABSOLUTE:
+    case R_LARCH_SOP_PUSH_DUP:
+    case R_LARCH_SOP_PUSH_GPREL:
+    case R_LARCH_SOP_PUSH_TLS_TPREL:
+    case R_LARCH_SOP_PUSH_TLS_GOT:
+    case R_LARCH_SOP_PUSH_TLS_GD:
+    case R_LARCH_SOP_PUSH_PLT_PCREL:
+    case R_LARCH_SOP_ASSERT:
+    case R_LARCH_SOP_NOT:
+    case R_LARCH_SOP_SUB:
+    case R_LARCH_SOP_SL:
+    case R_LARCH_SOP_SR:
+    case R_LARCH_SOP_ADD:
+    case R_LARCH_SOP_AND:
+    case R_LARCH_SOP_IF_ELSE:
+    case R_LARCH_SOP_POP_32_S_10_5:
+    case R_LARCH_SOP_POP_32_U_10_12:
+    case R_LARCH_SOP_POP_32_S_10_12:
+    case R_LARCH_SOP_POP_32_S_10_16:
+    case R_LARCH_SOP_POP_32_S_10_16_S2:
+    case R_LARCH_SOP_POP_32_S_5_20:
+    case R_LARCH_SOP_POP_32_S_0_5_10_16_S2:
+    case R_LARCH_SOP_POP_32_S_0_10_10_16_S2:
+    case R_LARCH_SOP_POP_32_U:
+    // Nor are we implementing these two reloc types that were probably added
+    // without much thought, and already proposed to be removed.
+    // See https://github.com/loongson/LoongArch-Documentation/issues/51
+    case R_LARCH_ADD24:
+    case R_LARCH_SUB24:
+    // Similarly for these two, long deprecated and unused even before the
+    // inception of LoongArch.
+    case R_LARCH_GNU_VTINHERIT:
+    case R_LARCH_GNU_VTENTRY:
+      Error(ctx) << *this << ": cannot handle deprecated relocation "
+                 << rel << " against symbol " << sym;
+      break;
+    default:
+      unreachable();
+    }
+
+#undef S
+#undef A
+#undef P
+#undef G
+#undef GP
+#undef TP
+#undef GD
+#undef IE
+  }
+}
+
+template <typename E>
+void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+    u8 *loc = base + rel.r_offset;
+
+    if (!sym.file) {
+      record_undef_error(ctx, rel);
+      continue;
+    }
+
+    SectionFragment<E> *frag;
+    i64 frag_addend;
+    std::tie(frag, frag_addend) = get_fragment(ctx, rel);
+
+#define S (frag ? frag->get_addr(ctx) : sym.get_addr(ctx))
+#define A (frag ? frag_addend : (i64)rel.r_addend)
+
+    switch (rel.r_type) {
+    case R_LARCH_32:
+      *(U32<E> *)loc = S + A;
+      break;
+    case R_LARCH_64:
+      if (std::optional<u64> val = get_tombstone(sym, frag))
+        *(U64<E> *)loc = *val;
+      else
+        *(U64<E> *)loc = S + A;
+      break;
+    case R_LARCH_ADD8:
+      *loc += S + A;
+      break;
+    case R_LARCH_ADD16:
+      *(U16<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD32:
+      *(U32<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD64:
+      *(U64<E> *)loc += S + A;
+      break;
+    case R_LARCH_SUB8:
+      *loc -= S + A;
+      break;
+    case R_LARCH_SUB16:
+      *(U16<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB32:
+      *(U32<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB64:
+      *(U64<E> *)loc -= S + A;
+      break;
+    default:
+      Fatal(ctx) << *this << ": invalid relocation for non-allocated sections: "
+                 << rel;
+      break;
+    }
+
+#undef S
+#undef A
+  }
+}
+
+template <typename E>
+void InputSection<E>::scan_relocations(Context<E> &ctx) {
+  assert(shdr().sh_flags & SHF_ALLOC);
+
+  this->reldyn_offset = file.num_dynrel * sizeof(ElfRel<E>);
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  // Scan relocations
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    if (rel.r_type == R_LARCH_RELAX)
+      continue;
+
+    if (rel.r_type == R_LARCH_MARK_LA || rel.r_type == R_LARCH_MARK_PCREL)
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+
+    if (!sym.file) {
+      record_undef_error(ctx, rel);
+      continue;
+    }
+
+    if (sym.is_ifunc())
+      sym.flags |= (NEEDS_GOT | NEEDS_PLT);
+
+    switch (rel.r_type) {
+    case R_LARCH_32:
+      if constexpr (E::is_64)
+        scan_rel(ctx, sym, rel, absrel_table);
+      else
+        scan_rel(ctx, sym, rel, dyn_absrel_table);
+      break;
+    case R_LARCH_64:
+      assert(E::is_64);
+      scan_rel(ctx, sym, rel, dyn_absrel_table);
+      break;
+    case R_LARCH_B16:
+    case R_LARCH_B21:
+    case R_LARCH_B26:
+      if (sym.is_imported)
+        sym.flags |= NEEDS_PLT;
+      break;
+    case R_LARCH_GOT_HI20:
+    case R_LARCH_GOT_PC_HI20:
+      sym.flags |= NEEDS_GOT;
+      break;
+    case R_LARCH_TLS_IE_HI20:
+    case R_LARCH_TLS_IE_PC_HI20:
+      ctx.has_gottp_rel = true;
+      sym.flags |= NEEDS_GOTTP;
+      break;
+    case R_LARCH_TLS_LD_PC_HI20:
+    case R_LARCH_TLS_GD_PC_HI20:
+    case R_LARCH_TLS_LD_HI20:
+    case R_LARCH_TLS_GD_HI20:
+      sym.flags |= NEEDS_TLSGD;
+      break;
+    case R_LARCH_32_PCREL:
+      scan_rel(ctx, sym, rel, pcrel_table);
+      break;
+    case R_LARCH_ABS_HI20:
+    case R_LARCH_ABS_LO12:
+    case R_LARCH_ABS64_LO20:
+    case R_LARCH_ABS64_HI12:
+    case R_LARCH_PCALA_HI20:
+    case R_LARCH_PCALA_LO12:
+    case R_LARCH_PCALA64_LO20:
+    case R_LARCH_PCALA64_HI12:
+    case R_LARCH_GOT_PC_LO12:
+    case R_LARCH_GOT64_PC_LO20:
+    case R_LARCH_GOT64_PC_HI12:
+    case R_LARCH_GOT_LO12:
+    case R_LARCH_GOT64_LO20:
+    case R_LARCH_GOT64_HI12:
+    case R_LARCH_TLS_LE_HI20:
+    case R_LARCH_TLS_LE_LO12:
+    case R_LARCH_TLS_LE64_LO20:
+    case R_LARCH_TLS_LE64_HI12:
+    case R_LARCH_TLS_IE_PC_LO12:
+    case R_LARCH_TLS_IE64_PC_LO20:
+    case R_LARCH_TLS_IE64_PC_HI12:
+    case R_LARCH_TLS_IE_LO12:
+    case R_LARCH_TLS_IE64_LO20:
+    case R_LARCH_TLS_IE64_HI12:
+    case R_LARCH_ADD8:
+    case R_LARCH_SUB8:
+    case R_LARCH_ADD16:
+    case R_LARCH_SUB16:
+    case R_LARCH_ADD32:
+    case R_LARCH_SUB32:
+    case R_LARCH_ADD64:
+    case R_LARCH_SUB64:
+      break;
+    case R_LARCH_SOP_PUSH_PCREL ... R_LARCH_SOP_POP_32_U:
+    case R_LARCH_ADD24:
+    case R_LARCH_SUB24:
+    case R_LARCH_GNU_VTINHERIT:
+    case R_LARCH_GNU_VTENTRY:
+      Error(ctx) << *this << ": cannot handle deprecated relocation "
+                 << rel << " against symbol " << sym;
+      break;
+    default:
+      Error(ctx) << *this << ": unknown relocation: " << rel;
+    }
+  }
+}
+
+#define INSTANTIATE(E)                                                       \
+  template void write_plt_header(Context<E> &, u8 *);                        \
+  template void write_plt_entry(Context<E> &, u8 *, Symbol<E> &);            \
+  template void write_pltgot_entry(Context<E> &, u8 *, Symbol<E> &);         \
+  template void                                                              \
+  EhFrameSection<E>::apply_reloc(Context<E> &, const ElfRel<E> &, u64, u64); \
+  template void InputSection<E>::apply_reloc_alloc(Context<E> &, u8 *);      \
+  template void InputSection<E>::apply_reloc_nonalloc(Context<E> &, u8 *);   \
+  template void InputSection<E>::scan_relocations(Context<E> &);
+
+INSTANTIATE(LOONGARCH64);
+INSTANTIATE(LOONGARCH32);
+} // namespace mold::elf

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -194,8 +194,8 @@ Options:
     -z notext
     -z textoff
 
-mold: supported targets: elf32-i386 elf64-x86-64 elf32-littlearm elf64-littleaarch64 elf32-littleriscv elf32-bigriscv elf64-littleriscv elf64-bigriscv elf64-powerpc elf64-powerpc elf64-powerpcle elf64-s390 elf64-sparc elf32-m68k
-mold: supported emulations: elf_i386 elf_x86_64 armelf_linux_eabi aarch64linux aarch64elf elf32lriscv elf32briscv elf64lriscv elf64briscv elf64ppc elf64lppc elf64_s390 elf64_sparc m68kelf)";
+mold: supported targets: elf32-i386 elf64-x86-64 elf32-littlearm elf64-littleaarch64 elf32-littleriscv elf32-bigriscv elf64-littleriscv elf64-bigriscv elf64-powerpc elf64-powerpc elf64-powerpcle elf64-s390 elf64-sparc elf32-m68k elf64-loongarch elf32-loongarch
+mold: supported emulations: elf_i386 elf_x86_64 armelf_linux_eabi aarch64linux aarch64elf elf32lriscv elf32briscv elf64lriscv elf64briscv elf64ppc elf64lppc elf64_s390 elf64_sparc m68kelf elf32loongarch elf64loongarch)";
 
 static std::vector<std::string> add_dashes(std::string name) {
   // Single-letter option
@@ -517,7 +517,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
                    << "   aarch64linux\n   armelf_linux_eabi\n   elf64lriscv\n"
                    << "   elf64briscv\n   elf32lriscv\n   elf32briscv\n"
                    << "   elf64ppc\n   elf64lppc\n   elf64_s390\n   elf64_sparc\n"
-                   << "   m68kelf";
+                   << "   m68kelf\n   elf32loongarch\n   elf64loongarch";
       version_shown = true;
     } else if (read_arg("m")) {
       if (arg == "elf_x86_64") {
@@ -546,6 +546,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
         ctx.arg.emulation = MachineType::SPARC64;
       } else if (arg == "m68kelf") {
         ctx.arg.emulation = MachineType::M68K;
+      } else if (arg == "elf32loongarch") {
+        ctx.arg.emulation = MachineType::LOONGARCH32;
+      } else if (arg == "elf64loongarch") {
+        ctx.arg.emulation = MachineType::LOONGARCH64;
       } else {
         Fatal(ctx) << "unknown -m argument: " << arg;
       }

--- a/elf/elf.h
+++ b/elf/elf.h
@@ -22,6 +22,8 @@ struct PPC64V2;
 struct S390X;
 struct SPARC64;
 struct M68K;
+struct LOONGARCH32;
+struct LOONGARCH64;
 
 template <typename E> struct ElfSym;
 template <typename E> struct ElfShdr;
@@ -40,25 +42,27 @@ static constexpr u32 R_NONE = 0;
 
 enum class MachineType {
   NONE, X86_64, I386, ARM64, ARM32, RV64LE, RV64BE, RV32LE, RV32BE,
-  PPC64V1, PPC64V2, S390X, SPARC64, M68K
+  PPC64V1, PPC64V2, S390X, SPARC64, M68K, LOONGARCH32, LOONGARCH64,
 };
 
 inline std::ostream &operator<<(std::ostream &out, MachineType mt) {
   switch (mt) {
-  case MachineType::NONE:    out << "none";      break;
-  case MachineType::X86_64:  out << "x86_64";    break;
-  case MachineType::I386:    out << "i386";      break;
-  case MachineType::ARM64:   out << "arm64";     break;
-  case MachineType::ARM32:   out << "arm32";     break;
-  case MachineType::RV64LE:  out << "riscv64";   break;
-  case MachineType::RV64BE:  out << "riscv64be"; break;
-  case MachineType::RV32LE:  out << "riscv32";   break;
-  case MachineType::RV32BE:  out << "riscv32be"; break;
-  case MachineType::PPC64V1: out << "ppc64v1";   break;
-  case MachineType::PPC64V2: out << "ppc64v2";   break;
-  case MachineType::S390X:   out << "s390x";     break;
-  case MachineType::SPARC64: out << "sparc64";   break;
-  case MachineType::M68K:    out << "m68k";      break;
+  case MachineType::NONE:         out << "none";          break;
+  case MachineType::X86_64:       out << "x86_64";        break;
+  case MachineType::I386:         out << "i386";          break;
+  case MachineType::ARM64:        out << "arm64";         break;
+  case MachineType::ARM32:        out << "arm32";         break;
+  case MachineType::RV64LE:       out << "riscv64";       break;
+  case MachineType::RV64BE:       out << "riscv64be";     break;
+  case MachineType::RV32LE:       out << "riscv32";       break;
+  case MachineType::RV32BE:       out << "riscv32be";     break;
+  case MachineType::PPC64V1:      out << "ppc64v1";       break;
+  case MachineType::PPC64V2:      out << "ppc64v2";       break;
+  case MachineType::S390X:        out << "s390x";         break;
+  case MachineType::SPARC64:      out << "sparc64";       break;
+  case MachineType::M68K:         out << "m68k";          break;
+  case MachineType::LOONGARCH64:  out << "loongarch64";   break;
+  case MachineType::LOONGARCH32:  out << "loongarch32";   break;
   }
   return out;
 }
@@ -190,6 +194,7 @@ static constexpr u32 EM_SPARC64 = 43;
 static constexpr u32 EM_X86_64 = 62;
 static constexpr u32 EM_AARCH64 = 183;
 static constexpr u32 EM_RISCV = 243;
+static constexpr u32 EM_LOONGARCH = 258;
 
 static constexpr u32 EI_CLASS = 4;
 static constexpr u32 EI_DATA = 5;
@@ -311,6 +316,13 @@ static constexpr u32 EF_SPARC_HAL_R1 = 0x000400;
 static constexpr u32 EF_SPARC_SUN_US3 = 0x000800;
 
 static constexpr u32 STO_RISCV_VARIANT_CC = 0x80;
+
+static constexpr u32 EF_LOONGARCH_ABI_SOFT_FLOAT = 0x1;
+static constexpr u32 EF_LOONGARCH_ABI_SINGLE_FLOAT = 0x2;
+static constexpr u32 EF_LOONGARCH_ABI_DOUBLE_FLOAT = 0x3;
+static constexpr u32 EF_LOONGARCH_ABI_MODIFIER_MASK = 0x7;
+static constexpr u32 EF_LOONGARCH_OBJABI_V1 = 0x40;
+static constexpr u32 EF_LOONGARCH_OBJABI_MASK = 0xC0;
 
 //
 // Relocation types
@@ -1750,6 +1762,197 @@ inline std::string rel_to_string<M68K>(u32 r_type) {
   return "unknown (" + std::to_string(r_type) + ")";
 }
 
+static constexpr u32 R_LARCH_NONE = 0;
+static constexpr u32 R_LARCH_32 = 1;
+static constexpr u32 R_LARCH_64 = 2;
+static constexpr u32 R_LARCH_RELATIVE = 3;
+static constexpr u32 R_LARCH_COPY = 4;
+static constexpr u32 R_LARCH_JUMP_SLOT = 5;
+static constexpr u32 R_LARCH_TLS_DTPMOD32 = 6;
+static constexpr u32 R_LARCH_TLS_DTPMOD64 = 7;
+static constexpr u32 R_LARCH_TLS_DTPREL32 = 8;
+static constexpr u32 R_LARCH_TLS_DTPREL64 = 9;
+static constexpr u32 R_LARCH_TLS_TPREL32 = 10;
+static constexpr u32 R_LARCH_TLS_TPREL64 = 11;
+static constexpr u32 R_LARCH_IRELATIVE = 12;
+static constexpr u32 R_LARCH_MARK_LA = 20;
+static constexpr u32 R_LARCH_MARK_PCREL = 21;
+static constexpr u32 R_LARCH_SOP_PUSH_PCREL = 22;
+static constexpr u32 R_LARCH_SOP_PUSH_ABSOLUTE = 23;
+static constexpr u32 R_LARCH_SOP_PUSH_DUP = 24;
+static constexpr u32 R_LARCH_SOP_PUSH_GPREL = 25;
+static constexpr u32 R_LARCH_SOP_PUSH_TLS_TPREL = 26;
+static constexpr u32 R_LARCH_SOP_PUSH_TLS_GOT = 27;
+static constexpr u32 R_LARCH_SOP_PUSH_TLS_GD = 28;
+static constexpr u32 R_LARCH_SOP_PUSH_PLT_PCREL = 29;
+static constexpr u32 R_LARCH_SOP_ASSERT = 30;
+static constexpr u32 R_LARCH_SOP_NOT = 31;
+static constexpr u32 R_LARCH_SOP_SUB = 32;
+static constexpr u32 R_LARCH_SOP_SL = 33;
+static constexpr u32 R_LARCH_SOP_SR = 34;
+static constexpr u32 R_LARCH_SOP_ADD = 35;
+static constexpr u32 R_LARCH_SOP_AND = 36;
+static constexpr u32 R_LARCH_SOP_IF_ELSE = 37;
+static constexpr u32 R_LARCH_SOP_POP_32_S_10_5 = 38;
+static constexpr u32 R_LARCH_SOP_POP_32_U_10_12 = 39;
+static constexpr u32 R_LARCH_SOP_POP_32_S_10_12 = 40;
+static constexpr u32 R_LARCH_SOP_POP_32_S_10_16 = 41;
+static constexpr u32 R_LARCH_SOP_POP_32_S_10_16_S2 = 42;
+static constexpr u32 R_LARCH_SOP_POP_32_S_5_20 = 43;
+static constexpr u32 R_LARCH_SOP_POP_32_S_0_5_10_16_S2 = 44;
+static constexpr u32 R_LARCH_SOP_POP_32_S_0_10_10_16_S2 = 45;
+static constexpr u32 R_LARCH_SOP_POP_32_U = 46;
+static constexpr u32 R_LARCH_ADD8 = 47;
+static constexpr u32 R_LARCH_ADD16 = 48;
+static constexpr u32 R_LARCH_ADD24 = 49;
+static constexpr u32 R_LARCH_ADD32 = 50;
+static constexpr u32 R_LARCH_ADD64 = 51;
+static constexpr u32 R_LARCH_SUB8 = 52;
+static constexpr u32 R_LARCH_SUB16 = 53;
+static constexpr u32 R_LARCH_SUB24 = 54;
+static constexpr u32 R_LARCH_SUB32 = 55;
+static constexpr u32 R_LARCH_SUB64 = 56;
+static constexpr u32 R_LARCH_GNU_VTINHERIT = 57;
+static constexpr u32 R_LARCH_GNU_VTENTRY = 58;
+static constexpr u32 R_LARCH_B16 = 64;
+static constexpr u32 R_LARCH_B21 = 65;
+static constexpr u32 R_LARCH_B26 = 66;
+static constexpr u32 R_LARCH_ABS_HI20 = 67;
+static constexpr u32 R_LARCH_ABS_LO12 = 68;
+static constexpr u32 R_LARCH_ABS64_LO20 = 69;
+static constexpr u32 R_LARCH_ABS64_HI12 = 70;
+static constexpr u32 R_LARCH_PCALA_HI20 = 71;
+static constexpr u32 R_LARCH_PCALA_LO12 = 72;
+static constexpr u32 R_LARCH_PCALA64_LO20 = 73;
+static constexpr u32 R_LARCH_PCALA64_HI12 = 74;
+static constexpr u32 R_LARCH_GOT_PC_HI20 = 75;
+static constexpr u32 R_LARCH_GOT_PC_LO12 = 76;
+static constexpr u32 R_LARCH_GOT64_PC_LO20 = 77;
+static constexpr u32 R_LARCH_GOT64_PC_HI12 = 78;
+static constexpr u32 R_LARCH_GOT_HI20 = 79;
+static constexpr u32 R_LARCH_GOT_LO12 = 80;
+static constexpr u32 R_LARCH_GOT64_LO20 = 81;
+static constexpr u32 R_LARCH_GOT64_HI12 = 82;
+static constexpr u32 R_LARCH_TLS_LE_HI20 = 83;
+static constexpr u32 R_LARCH_TLS_LE_LO12 = 84;
+static constexpr u32 R_LARCH_TLS_LE64_LO20 = 85;
+static constexpr u32 R_LARCH_TLS_LE64_HI12 = 86;
+static constexpr u32 R_LARCH_TLS_IE_PC_HI20 = 87;
+static constexpr u32 R_LARCH_TLS_IE_PC_LO12 = 88;
+static constexpr u32 R_LARCH_TLS_IE64_PC_LO20 = 89;
+static constexpr u32 R_LARCH_TLS_IE64_PC_HI12 = 90;
+static constexpr u32 R_LARCH_TLS_IE_HI20 = 91;
+static constexpr u32 R_LARCH_TLS_IE_LO12 = 92;
+static constexpr u32 R_LARCH_TLS_IE64_LO20 = 93;
+static constexpr u32 R_LARCH_TLS_IE64_HI12 = 94;
+static constexpr u32 R_LARCH_TLS_LD_PC_HI20 = 95;
+static constexpr u32 R_LARCH_TLS_LD_HI20 = 96;
+static constexpr u32 R_LARCH_TLS_GD_PC_HI20 = 97;
+static constexpr u32 R_LARCH_TLS_GD_HI20 = 98;
+static constexpr u32 R_LARCH_32_PCREL = 99;
+static constexpr u32 R_LARCH_RELAX = 100;
+
+template <>
+inline std::string rel_to_string<LOONGARCH64>(u32 r_type) {
+  switch (r_type) {
+  case R_LARCH_NONE: return "R_LARCH_NONE";
+  case R_LARCH_32: return "R_LARCH_32";
+  case R_LARCH_64: return "R_LARCH_64";
+  case R_LARCH_RELATIVE: return "R_LARCH_RELATIVE";
+  case R_LARCH_COPY: return "R_LARCH_COPY";
+  case R_LARCH_JUMP_SLOT: return "R_LARCH_JUMP_SLOT";
+  case R_LARCH_TLS_DTPMOD32: return "R_LARCH_TLS_DTPMOD32";
+  case R_LARCH_TLS_DTPMOD64: return "R_LARCH_TLS_DTPMOD64";
+  case R_LARCH_TLS_DTPREL32: return "R_LARCH_TLS_DTPREL32";
+  case R_LARCH_TLS_DTPREL64: return "R_LARCH_TLS_DTPREL64";
+  case R_LARCH_TLS_TPREL32: return "R_LARCH_TLS_TPREL32";
+  case R_LARCH_TLS_TPREL64: return "R_LARCH_TLS_TPREL64";
+  case R_LARCH_IRELATIVE: return "R_LARCH_IRELATIVE";
+  case R_LARCH_MARK_LA: return "R_LARCH_MARK_LA";
+  case R_LARCH_MARK_PCREL: return "R_LARCH_MARK_PCREL";
+  case R_LARCH_SOP_PUSH_PCREL: return "R_LARCH_SOP_PUSH_PCREL";
+  case R_LARCH_SOP_PUSH_ABSOLUTE: return "R_LARCH_SOP_PUSH_ABSOLUTE";
+  case R_LARCH_SOP_PUSH_DUP: return "R_LARCH_SOP_PUSH_DUP";
+  case R_LARCH_SOP_PUSH_GPREL: return "R_LARCH_SOP_PUSH_GPREL";
+  case R_LARCH_SOP_PUSH_TLS_TPREL: return "R_LARCH_SOP_PUSH_TLS_TPREL";
+  case R_LARCH_SOP_PUSH_TLS_GOT: return "R_LARCH_SOP_PUSH_TLS_GOT";
+  case R_LARCH_SOP_PUSH_TLS_GD: return "R_LARCH_SOP_PUSH_TLS_GD";
+  case R_LARCH_SOP_PUSH_PLT_PCREL: return "R_LARCH_SOP_PUSH_PLT_PCREL";
+  case R_LARCH_SOP_ASSERT: return "R_LARCH_SOP_ASSERT";
+  case R_LARCH_SOP_NOT: return "R_LARCH_SOP_NOT";
+  case R_LARCH_SOP_SUB: return "R_LARCH_SOP_SUB";
+  case R_LARCH_SOP_SL: return "R_LARCH_SOP_SL";
+  case R_LARCH_SOP_SR: return "R_LARCH_SOP_SR";
+  case R_LARCH_SOP_ADD: return "R_LARCH_SOP_ADD";
+  case R_LARCH_SOP_AND: return "R_LARCH_SOP_AND";
+  case R_LARCH_SOP_IF_ELSE: return "R_LARCH_SOP_IF_ELSE";
+  case R_LARCH_SOP_POP_32_S_10_5: return "R_LARCH_SOP_POP_32_S_10_5";
+  case R_LARCH_SOP_POP_32_U_10_12: return "R_LARCH_SOP_POP_32_U_10_12";
+  case R_LARCH_SOP_POP_32_S_10_12: return "R_LARCH_SOP_POP_32_S_10_12";
+  case R_LARCH_SOP_POP_32_S_10_16: return "R_LARCH_SOP_POP_32_S_10_16";
+  case R_LARCH_SOP_POP_32_S_10_16_S2: return "R_LARCH_SOP_POP_32_S_10_16_S2";
+  case R_LARCH_SOP_POP_32_S_5_20: return "R_LARCH_SOP_POP_32_S_5_20";
+  case R_LARCH_SOP_POP_32_S_0_5_10_16_S2: return "R_LARCH_SOP_POP_32_S_0_5_10_16_S2";
+  case R_LARCH_SOP_POP_32_S_0_10_10_16_S2: return "R_LARCH_SOP_POP_32_S_0_10_10_16_S2";
+  case R_LARCH_SOP_POP_32_U: return "R_LARCH_SOP_POP_32_U";
+  case R_LARCH_ADD8: return "R_LARCH_ADD8";
+  case R_LARCH_ADD16: return "R_LARCH_ADD16";
+  case R_LARCH_ADD24: return "R_LARCH_ADD24";
+  case R_LARCH_ADD32: return "R_LARCH_ADD32";
+  case R_LARCH_ADD64: return "R_LARCH_ADD64";
+  case R_LARCH_SUB8: return "R_LARCH_SUB8";
+  case R_LARCH_SUB16: return "R_LARCH_SUB16";
+  case R_LARCH_SUB24: return "R_LARCH_SUB24";
+  case R_LARCH_SUB32: return "R_LARCH_SUB32";
+  case R_LARCH_SUB64: return "R_LARCH_SUB64";
+  case R_LARCH_GNU_VTINHERIT: return "R_LARCH_GNU_VTINHERIT";
+  case R_LARCH_GNU_VTENTRY: return "R_LARCH_GNU_VTENTRY";
+  case R_LARCH_B16: return "R_LARCH_B16";
+  case R_LARCH_B21: return "R_LARCH_B21";
+  case R_LARCH_B26: return "R_LARCH_B26";
+  case R_LARCH_ABS_HI20: return "R_LARCH_ABS_HI20";
+  case R_LARCH_ABS_LO12: return "R_LARCH_ABS_LO12";
+  case R_LARCH_ABS64_LO20: return "R_LARCH_ABS64_LO20";
+  case R_LARCH_ABS64_HI12: return "R_LARCH_ABS64_HI12";
+  case R_LARCH_PCALA_HI20: return "R_LARCH_PCALA_HI20";
+  case R_LARCH_PCALA_LO12: return "R_LARCH_PCALA_LO12";
+  case R_LARCH_PCALA64_LO20: return "R_LARCH_PCALA64_LO20";
+  case R_LARCH_PCALA64_HI12: return "R_LARCH_PCALA64_HI12";
+  case R_LARCH_GOT_PC_HI20: return "R_LARCH_GOT_PC_HI20";
+  case R_LARCH_GOT_PC_LO12: return "R_LARCH_GOT_PC_LO12";
+  case R_LARCH_GOT64_PC_LO20: return "R_LARCH_GOT64_PC_LO20";
+  case R_LARCH_GOT64_PC_HI12: return "R_LARCH_GOT64_PC_HI12";
+  case R_LARCH_GOT_HI20: return "R_LARCH_GOT_HI20";
+  case R_LARCH_GOT_LO12: return "R_LARCH_GOT_LO12";
+  case R_LARCH_GOT64_LO20: return "R_LARCH_GOT64_LO20";
+  case R_LARCH_GOT64_HI12: return "R_LARCH_GOT64_HI12";
+  case R_LARCH_TLS_LE_HI20: return "R_LARCH_TLS_LE_HI20";
+  case R_LARCH_TLS_LE_LO12: return "R_LARCH_TLS_LE_LO12";
+  case R_LARCH_TLS_LE64_LO20: return "R_LARCH_TLS_LE64_LO20";
+  case R_LARCH_TLS_LE64_HI12: return "R_LARCH_TLS_LE64_HI12";
+  case R_LARCH_TLS_IE_PC_HI20: return "R_LARCH_TLS_IE_PC_HI20";
+  case R_LARCH_TLS_IE_PC_LO12: return "R_LARCH_TLS_IE_PC_LO12";
+  case R_LARCH_TLS_IE64_PC_LO20: return "R_LARCH_TLS_IE64_PC_LO20";
+  case R_LARCH_TLS_IE64_PC_HI12: return "R_LARCH_TLS_IE64_PC_HI12";
+  case R_LARCH_TLS_IE_HI20: return "R_LARCH_TLS_IE_HI20";
+  case R_LARCH_TLS_IE_LO12: return "R_LARCH_TLS_IE_LO12";
+  case R_LARCH_TLS_IE64_LO20: return "R_LARCH_TLS_IE64_LO20";
+  case R_LARCH_TLS_IE64_HI12: return "R_LARCH_TLS_IE64_HI12";
+  case R_LARCH_TLS_LD_PC_HI20: return "R_LARCH_TLS_LD_PC_HI20";
+  case R_LARCH_TLS_LD_HI20: return "R_LARCH_TLS_LD_HI20";
+  case R_LARCH_TLS_GD_PC_HI20: return "R_LARCH_TLS_GD_PC_HI20";
+  case R_LARCH_TLS_GD_HI20: return "R_LARCH_TLS_GD_HI20";
+  case R_LARCH_32_PCREL: return "R_LARCH_32_PCREL";
+  case R_LARCH_RELAX: return "R_LARCH_RELAX";
+  }
+  return "unknown (" + std::to_string(r_type) + ")";
+}
+
+template <>
+inline std::string rel_to_string<LOONGARCH32>(u32 r_type) {
+  return rel_to_string<LOONGARCH64>(r_type);
+}
+
 //
 // DWARF data types
 //
@@ -2445,6 +2648,10 @@ static constexpr bool is_s390x = std::is_same_v<E, S390X>;
 template <typename E>
 static constexpr bool is_m68k = std::is_same_v<E, M68K>;
 
+template <typename E>
+static constexpr bool is_loongarch = std::is_same_v<E, LOONGARCH64> ||
+  std::is_same_v<E, LOONGARCH32>;
+
 struct X86_64 {
   static constexpr u32 R_COPY = R_X86_64_COPY;
   static constexpr u32 R_GLOB_DAT = R_X86_64_GLOB_DAT;
@@ -2933,5 +3140,77 @@ template <> struct ElfVerdef<M68K>  : EBVerdef {};
 template <> struct ElfVerdaux<M68K> : EBVerdaux {};
 template <> struct ElfChdr<M68K>    : EB32Chdr {};
 template <> struct ElfNhdr<M68K>    : EBNhdr {};
+
+struct LOONGARCH64 {
+  static constexpr u32 R_COPY = R_LARCH_COPY;
+  static constexpr u32 R_GLOB_DAT = R_LARCH_64;
+  static constexpr u32 R_JUMP_SLOT = R_LARCH_JUMP_SLOT;
+  static constexpr u32 R_ABS = R_LARCH_64;
+  static constexpr u32 R_RELATIVE = R_LARCH_RELATIVE;
+  static constexpr u32 R_IRELATIVE = R_LARCH_IRELATIVE;
+  static constexpr u32 R_DTPOFF = R_LARCH_TLS_DTPREL64;
+  static constexpr u32 R_TPOFF = R_LARCH_TLS_TPREL64;
+  static constexpr u32 R_DTPMOD = R_LARCH_TLS_DTPMOD64;
+
+  static constexpr MachineType machine_type = MachineType::LOONGARCH64;
+  static constexpr bool is_64 = true;
+  static constexpr bool is_le = true;
+  static constexpr u32 page_size = 16384;
+  static constexpr u32 e_machine = EM_LOONGARCH;
+  static constexpr u32 plt_hdr_size = 32;
+  static constexpr u32 plt_size = 16;
+  static constexpr u32 pltgot_size = 16;
+
+  static constexpr u32 tls_dtp_offset = 0;
+};
+
+template <> struct ElfSym<LOONGARCH64>     : EL64Sym {};
+template <> struct ElfShdr<LOONGARCH64>    : EL64Shdr {};
+template <> struct ElfEhdr<LOONGARCH64>    : EL64Ehdr {};
+template <> struct ElfPhdr<LOONGARCH64>    : EL64Phdr {};
+template <> struct ElfRel<LOONGARCH64>     : EL64Rela { using EL64Rela::EL64Rela; };
+template <> struct ElfDyn<LOONGARCH64>     : EL64Dyn {};
+template <> struct ElfVerneed<LOONGARCH64> : ELVerneed {};
+template <> struct ElfVernaux<LOONGARCH64> : ELVernaux {};
+template <> struct ElfVerdef<LOONGARCH64>  : ELVerdef {};
+template <> struct ElfVerdaux<LOONGARCH64> : ELVerdaux {};
+template <> struct ElfChdr<LOONGARCH64>    : EL64Chdr {};
+template <> struct ElfNhdr<LOONGARCH64>    : ELNhdr {};
+
+struct LOONGARCH32 {
+  static constexpr u32 R_COPY = R_LARCH_COPY;
+  static constexpr u32 R_GLOB_DAT = R_LARCH_32;
+  static constexpr u32 R_JUMP_SLOT = R_LARCH_JUMP_SLOT;
+  static constexpr u32 R_ABS = R_LARCH_32;
+  static constexpr u32 R_RELATIVE = R_LARCH_RELATIVE;
+  static constexpr u32 R_IRELATIVE = R_LARCH_IRELATIVE;
+  static constexpr u32 R_DTPOFF = R_LARCH_TLS_DTPREL32;
+  static constexpr u32 R_TPOFF = R_LARCH_TLS_TPREL32;
+  static constexpr u32 R_DTPMOD = R_LARCH_TLS_DTPMOD32;
+
+  static constexpr MachineType machine_type = MachineType::LOONGARCH32;
+  static constexpr bool is_64 = false;
+  static constexpr bool is_le = true;
+  static constexpr u32 page_size = 16384;
+  static constexpr u32 e_machine = EM_LOONGARCH;
+  static constexpr u32 plt_hdr_size = 32;
+  static constexpr u32 plt_size = 16;
+  static constexpr u32 pltgot_size = 16;
+
+  static constexpr u32 tls_dtp_offset = 0;
+};
+
+template <> struct ElfSym<LOONGARCH32>     : EL32Sym {};
+template <> struct ElfShdr<LOONGARCH32>    : EL32Shdr {};
+template <> struct ElfEhdr<LOONGARCH32>    : EL32Ehdr {};
+template <> struct ElfPhdr<LOONGARCH32>    : EL32Phdr {};
+template <> struct ElfRel<LOONGARCH32>     : EL32Rela { using EL32Rela::EL32Rela; };
+template <> struct ElfDyn<LOONGARCH32>     : EL32Dyn {};
+template <> struct ElfVerneed<LOONGARCH32> : ELVerneed {};
+template <> struct ElfVernaux<LOONGARCH32> : ELVernaux {};
+template <> struct ElfVerdef<LOONGARCH32>  : ELVerdef {};
+template <> struct ElfVerdaux<LOONGARCH32> : ELVerdaux {};
+template <> struct ElfChdr<LOONGARCH32>    : EL32Chdr {};
+template <> struct ElfNhdr<LOONGARCH32>    : ELNhdr {};
 
 } // namespace mold::elf

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -64,6 +64,8 @@ MachineType get_machine_type(Context<E> &ctx, MappedFile<Context<E>> *mf) {
       return MachineType::SPARC64;
     case EM_68K:
       return MachineType::M68K;
+    case EM_LOONGARCH:
+      return is_64 ? MachineType::LOONGARCH64 : MachineType::LOONGARCH32;
     default:
       return MachineType::NONE;
     }
@@ -334,6 +336,10 @@ static int redo_main(int argc, char **argv, MachineType ty) {
     return elf_main<SPARC64>(argc, argv);
   case MachineType::M68K:
     return elf_main<M68K>(argc, argv);
+  case MachineType::LOONGARCH32:
+    return elf_main<LOONGARCH32>(argc, argv);
+  case MachineType::LOONGARCH64:
+    return elf_main<LOONGARCH64>(argc, argv);
   default:
     unreachable();
   }
@@ -718,6 +724,8 @@ extern template int elf_main<PPC64V2>(int, char **);
 extern template int elf_main<S390X>(int, char **);
 extern template int elf_main<SPARC64>(int, char **);
 extern template int elf_main<M68K>(int, char **);
+extern template int elf_main<LOONGARCH32>(int, char **);
+extern template int elf_main<LOONGARCH64>(int, char **);
 
 int main(int argc, char **argv) {
   return elf_main<X86_64>(argc, argv);

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -228,6 +228,8 @@ static void init_thread_pointers(Context<E> &ctx, ElfPhdr<E> phdr) {
     ctx.tp_addr = align_down(phdr.p_vaddr - sizeof(Word<E>) * 2, phdr.p_align);
   } else if constexpr (is_ppc<E> || is_m68k<E>) {
     ctx.tp_addr = phdr.p_vaddr + 0x7000;
+  } else if constexpr (is_loongarch<E>) {
+    ctx.tp_addr = phdr.p_vaddr;
   } else {
     static_assert(is_riscv<E>);
     ctx.tp_addr = phdr.p_vaddr;

--- a/test/elf/CMakeLists.txt
+++ b/test/elf/CMakeLists.txt
@@ -54,6 +54,7 @@ add_target(powerpc64le-linux-gnu)
 add_target(sparc64-linux-gnu)
 add_target(s390x-linux-gnu)
 add_target(m68k-linux-gnu)
+add_target(loongarch64-linux-gnu)
 
 if(MOLD_ENABLE_QEMU_TESTS_RV32)
   add_target(riscv32-linux-gnu)


### PR DESCRIPTION
Note that it just a test version. I did not do many test on it, just link llvm and itself. And some codes from lld(WIP), see[1].

Follows are result of selftest, and simple analysis, on CLFS-7.2,

The following tests did not run:
  22 - loongarch64-compress-debug-sections (Skipped)
  23 - loongarch64-compressed-debug-info (Skipped)
  28 - loongarch64-dead-debug-sections (Skipped)
  90 - loongarch64-ifunc-static-pie (Skipped)
 115 - loongarch64-lto-llvm (Skipped)
 174 - loongarch64-static-pie (Skipped)
 207 - loongarch64-tlsdesc-import (Skipped)
 208 - loongarch64-tlsdesc-static (Skipped)
 209 - loongarch64-tlsdesc (Skipped)

The following tests FAILED:
   1 - loongarch64-abs-error (Failed)             Has no no-PIC, should skip?
  24 - loongarch64-copyrel-alignment (Failed)     Copyreloc should skip?
  25 - loongarch64-copyrel-protected (Failed)     Ditto.
 126 - loongarch64-nocopyreloc (Failed)           Ditto.
  39 - loongarch64-dt-init (Failed)               New glibc version, no init-fini.
 133 - loongarch64-pack-dyn-relocs-relr (Failed)  binutils/llvm-readelf error?
 144 - loongarch64-range-extension-thunk (Failed) branch b26(plt) out of range
 164 - loongarch64-section-start (Failed)         Ditto.

Link: [1] https://reviews.llvm.org/D138135
Signed-off-by: Jinyang He <hejinyang@loongson.cn>